### PR TITLE
Set Pipeline context information as environment variables in the EC2 instance via the SSM document

### DIFF
--- a/lambda/job-api/lambda.py
+++ b/lambda/job-api/lambda.py
@@ -48,6 +48,10 @@ def run_command(event):
     output_artifact_path = event['outputArtifactPath']
     output_bucket_name = event['outputBucketName']
     output_object_key = event['outputObjectKey']
+    
+    pipeline_execution_id = event['executionId']
+    pipeline_arn = event['pipelineArn']
+    pipeline_name = event['pipelineName']
 
     # Send command to the builder instance
     response = ssm.send_command(
@@ -61,7 +65,10 @@ def run_command(event):
             'workingDirectory': [command_working_directory],
             'outputArtifactPath': [output_artifact_path],
             'outputBucketName': [output_bucket_name],
-            'outputObjectKey': [output_object_key]
+            'outputObjectKey': [output_object_key],
+            'executionId': [pipeline_execution_id],
+            'pipelineArn': [pipeline_arn]
+            'pipelineName': [pipeline_name]
         },
         CloudWatchOutputConfig={
             'CloudWatchOutputEnabled': True

--- a/lambda/job-api/lambda.py
+++ b/lambda/job-api/lambda.py
@@ -67,7 +67,7 @@ def run_command(event):
             'outputBucketName': [output_bucket_name],
             'outputObjectKey': [output_object_key],
             'executionId': [pipeline_execution_id],
-            'pipelineArn': [pipeline_arn]
+            'pipelineArn': [pipeline_arn],
             'pipelineName': [pipeline_name]
         },
         CloudWatchOutputConfig={

--- a/lambda/poller/lambda.py
+++ b/lambda/poller/lambda.py
@@ -195,11 +195,20 @@ def start_job_flow(job_id, job):
     command_text = configuration.get('Command')
     working_directory = configuration.get('WorkingDirectory', '')
     output_artifact_path = configuration.get('OutputArtifactPath', '')
+    
+    # reference https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/CodePipeline/TPipelineContext.html
+    pipeline_context = get_job_attribute(job, 'pipelineContext', {})
+    pipeline_execution_id = pipeline_context.get('PipelineExecutionId')
+    pipeline_arn = pipeline_context.get('PipelineArn')
+    pipeline_name = pipeline_context.get('PipelineName')
 
     sfn_input = {
         "params": {
             "pipeline": {
-                "jobId": job_id
+                "jobId": job_id,
+                "executionId": pipeline_execution_id,
+                "arn": pipeline_arn,
+                "name": pipeline_name
             },
             "artifacts": {
                 "input": {

--- a/template.yml
+++ b/template.yml
@@ -410,7 +410,10 @@ Resources:
                         "inputObjectKey.$": "$.params.artifacts.input.objectKey",
                         "outputArtifactPath.$": "$.params.artifacts.output.path",
                         "outputBucketName.$": "$.params.artifacts.output.bucketName",
-                        "outputObjectKey.$": "$.params.artifacts.output.objectKey"
+                        "outputObjectKey.$": "$.params.artifacts.output.objectKey",
+                        "executionId.$": "$.params.pipeline.executionId",
+                        "pipelineArn.$": "$.params.pipeline.arn",
+                        "pipelineName.$": "$.params.pipeline.name"
                       },
                       "Next": "Wait Command Completion"
                     },

--- a/template.yml
+++ b/template.yml
@@ -221,6 +221,21 @@ Resources:
             type: String
             default: '3600'
             allowedPattern: "([1-9][0-9]{0,3})|(1[0-9]{1,4})|(2[0-7][0-9]{1,3})|(28[0-7][0-9]{1,2})|(28800)"
+          executionId:
+            description: "(Required) Specify the pipeline execution ID"
+            type: String
+            default: ''
+            maxChars: 4096
+          pipelineArn:
+            description: "(Required) Specify the pipeline ARN"
+            type: String
+            default: ''
+            maxChars: 4096
+          pipelineName:
+            description: "(Required) Specify the pipeline Name"
+            type: String
+            default: ''
+            maxChars: 4096
         mainSteps:
           - name: win_enable_docker
             action: aws:configureDocker
@@ -236,6 +251,9 @@ Resources:
               runCommand:
                 # Ensure that if a command fails the script does not proceed to the following commands
                 - "$ErrorActionPreference = \"Stop\""
+                - "$ENV:PipelineExecutionId = \"{{ executionId }}\""
+                - "$ENV:PipelineArn = \"{{ pipelineArn }}\""
+                - "$ENV:PipelineName = \"{{ pipelineName }}\""
 
                 - "$jobDirectory = \"{{ workingDirectory }}\""
                 # Create temporary folder for build artifacts, if not provided

--- a/template.yml
+++ b/template.yml
@@ -194,6 +194,21 @@ Resources:
             description: "(Required) Specify the commands to run or the paths to existing scripts on the instance."
             type: String
             displayType: textarea
+          executionId:
+            description: "(Required) Specify the pipeline execution ID"
+            type: String
+            default: ''
+            maxChars: 4096
+          pipelineArn:
+            description: "(Required) Specify the pipeline ARN"
+            type: String
+            default: ''
+            maxChars: 4096
+          pipelineName:
+            description: "(Required) Specify the pipeline Name"
+            type: String
+            default: ''
+            maxChars: 4096
           workingDirectory:
             type: String
             default: ''
@@ -221,21 +236,6 @@ Resources:
             type: String
             default: '3600'
             allowedPattern: "([1-9][0-9]{0,3})|(1[0-9]{1,4})|(2[0-7][0-9]{1,3})|(28[0-7][0-9]{1,2})|(28800)"
-          executionId:
-            description: "(Required) Specify the pipeline execution ID"
-            type: String
-            default: ''
-            maxChars: 4096
-          pipelineArn:
-            description: "(Required) Specify the pipeline ARN"
-            type: String
-            default: ''
-            maxChars: 4096
-          pipelineName:
-            description: "(Required) Specify the pipeline Name"
-            type: String
-            default: ''
-            maxChars: 4096
         mainSteps:
           - name: win_enable_docker
             action: aws:configureDocker
@@ -300,6 +300,9 @@ Resources:
             action: aws:runShellScript
             inputs:
               runCommand:
+                - "export PipelineExecutionId={{ executionId }}"
+                - "export PipelineArn={{ pipelineArn }}"
+                - "export PipelineName={{ pipelineName }}"
                 - "aws s3 cp s3://{{ inputBucketName }}/{{ inputObjectKey }}  artifact.zip"
                 - "unzip artifact.zip"
                 - "{{ commands }}"


### PR DESCRIPTION
This set the Pipeline ExecutionId, ARN and Name as environment variables on the EC2 instance prior to executing the build commands. The build commands can now use this information to create a build number based on the execution id as an example.