### PR TITLE
Fix typo in the cloudformation script

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -601,7 +601,7 @@ Resources:
             },
             "Report Completion": {
               "Type": "Task",
-              "Resource": "${JobCompletionHandler.Arn}"
+              "Resource": "${JobCompletionHandler.Arn}",
               "End": true
             }
           }


### PR DESCRIPTION
The json template for the state machine has a typo in it.
